### PR TITLE
svelte/vue fix, add .js/.ts support, fix selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Fix for Svelte/Vue
 - Add support for `*.js` and `*.ts` files
+- Added support for multiple cursor selections
 - Fix selection after toggle to include the initial block comment indicator
 - Code refactor/cleanup
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "html-nested-comments" extension will be documented i
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [4.0.0] 🔖 Version 4.0
+
+- Fix for Svelte/Vue
+- Add support for `*.js` and `*.ts` files
+- Fix selection after toggle to include the initial block comment indicator
+- Code refactor/cleanup
+- 
 ## [3.0.3] 💄 Update Icon Transparency
 
 ## [3.0.2] 🔧 Add Publisher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [4.0.0] 🔖 Version 4.0
 
-- Fix for Svelte/Vue
-- Add support for `*.js` and `*.ts` files
+- Added support for `*.js` and `*.ts` files
 - Added support for multiple cursor selections
-- Fix selection after toggle to include the initial block comment indicator
-- Code refactor/cleanup
-- 
+- Fixed Svelte/Vue support
+- Fixed Selection after commenting to include the initial block comment indicator. 
+- Fixed Selection starting with a block comment indicator and having an ending block comment indicator in middle with additional text selected. It would uncomment rather than comment.
+- Fixed Selection ending on line with additional unselected content. This would cause additional unselected content to be deleted on nesting or unnesting. 
+- Change Code refactor/cleanup
+  
 ## [3.0.3] 💄 Update Icon Transparency
 
 ## [3.0.2] 🔧 Add Publisher

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The following languages are supported:
 - css
 - htm
 - html
+- js
 - jsx
 - md
 - njk
@@ -125,6 +126,7 @@ The following languages are supported:
 - svelte
 - svg
 - tpl
+- ts
 - tsx
 - twig
 - vue

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 If your code contains a comment, and you want to add a new comment to temporarily disable a block or portion of code, the built in commenting functionality does not actually place the comment tags in expected locations. If an existing comment is included in the content being commented out, the first instance of a `-->` or `*/` closing comment tag will end the entire comment.
 
-This extension will convert pre-existing comments to safe characters, allowing a new block comment that includes the original comment. It also reverses the effect to uncomment the same block of code.
+This extension will convert pre-existing comments to safe characters, allowing a new block comment that includes the original comment. It also reverses the effect to uncomment the same block of code. Additionally, this extension will work with multiple cursor selections.
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "nested-comments",
 	"displayName": "Nested Comments",
 	"description": "This is a VSCode extension for toggling nested comments.",
-	"version": "3.0.4",
+	"version": "4.0.0",
 	"author": {
 		"email": "code@philsinatra.com",
 		"name": "Phil Sinatra",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,8 @@ class NestComments {
 			'xsl',
 			'xslt'
 		]
-		if (!supported.indexOf(doc.languageId)) {
+
+		if (supported.indexOf(doc.languageId) === -1) {
 			vscode.window.showInformationMessage(`${doc.languageId} file format not supported!`)
 			return
 		} else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,29 +80,23 @@ class NestComments {
 			const range = new vscode.Range(startPos, endPos)
 			edit.replace(editor.document.uri, range, modText)
 			await vscode.workspace.applyEdit(edit)
-			editor.selections = [
-				new vscode.Selection(
-					startPos,
-					new vscode.Position(endPos.line, endPos.character + (modText.length - selText.length))
-				)
-			]
-			return vscode.workspace.applyEdit(edit)
+			let delta = modText.length - selText.length
+			editor.selections = [new vscode.Selection(startPos, endPos.translate(0, delta))]
+			return
 		}
 	}
 }
 
 function wrappingRootTag(text, selection) {
 	let tag = [...text.matchAll(/<(\w+).*?>(.*)<\/\1>/gms)].find(tag => tag[2].includes(selection))
-	tag = tag ? tag[1] : tag
+	if (tag) tag = tag[1]
 	if (tag === 'script') return 'javascript'
 	else if (tag === 'style') return 'css'
 	else return 'html'
 }
 
 function toggleComment(text, prefix, suffix, nestedPrefix, nestedSuffix) {
-	const escape = txt => txt.replace(/[-[\]{}()*+?.,\\/^$|#\s]/g, '\\$&')
-	let startWithPrefix = new RegExp(`^\s*${escape(prefix)}`, 'g')
-	if (text.match(startWithPrefix)) {
+	if (text.trimStart().startsWith(prefix)) {
 		text = text.replaceAll(prefix, '')
 		text = text.replaceAll(suffix, '')
 		text = text.replaceAll(nestedPrefix, prefix)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,16 +39,15 @@ class NestComments {
 			'xsl',
 			'xslt'
 		]
-
 		if (supported.indexOf(doc.languageId) === -1) {
 			vscode.window.showInformationMessage(`${doc.languageId} file format not supported!`)
 			return
 		} else {
-			const selection = editor.selection
 			const allText = editor.document.getText()
-			const selText = editor.document.getText(selection)
+			const selText = editor.document.getText(editor.selection)
 			let language = doc.languageId
 			let modText = ''
+
 			if (language === 'svelte' || language === 'vue') language = wrappingRootTag(allText, selText)
 			switch (language) {
 				case 'javascript':
@@ -72,17 +71,7 @@ class NestComments {
 					modText = toggleComment(selText, '<!--', ' -->', '<!~~', '~~>')
 					break
 			}
-			let edit = new vscode.WorkspaceEdit()
-			let startPos = new vscode.Position(selection.start.line, selection.start.character)
-			const endPos = new vscode.Position(
-				selection.start.line + selText.split(/\r\n|\r|\n/).length - 1,
-				selection.start.character + selText.length
-			)
-			const range = new vscode.Range(startPos, endPos)
-			edit.replace(editor.document.uri, range, modText)
-			await vscode.workspace.applyEdit(edit)
-			let delta = modText.length - selText.length
-			editor.selections = [new vscode.Selection(startPos, endPos.translate(0, delta))]
+			editor.edit(editBuilder => editBuilder.replace(editor.selection, modText))
 			return
 		}
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 class NestComments {
-	async updateNestedComments() {
+	updateNestedComments() {
 		let editor = vscode.window.activeTextEditor
 		if (!editor) return
 		const doc = editor.document
@@ -43,36 +43,41 @@ class NestComments {
 			vscode.window.showInformationMessage(`${doc.languageId} file format not supported!`)
 			return
 		} else {
-			const allText = editor.document.getText()
-			const selText = editor.document.getText(editor.selection)
-			let language = doc.languageId
-			let modText = ''
+			return editor.edit(editBuilder => {
+				editor.selections.map(selection => {
+					const allText = editor.document.getText()
+					const selText = editor.document.getText(selection)
 
-			if (language === 'svelte' || language === 'vue') language = wrappingRootTag(allText, selText)
-			switch (language) {
-				case 'javascript':
-				case 'typescript':
-				case 'css':
-					modText = toggleComment(selText, '/*', '*/', '/~', '~/')
-					break
-				case 'javascriptreact':
-				case 'typescriptreact':
-					modText = toggleComment(selText, '{/*', '*/}', '/~', '~/')
-					break
-				case 'tpl':
-				case 'twig':
-					modText = toggleComment(selText, '{#', '#}', '{~#', '#~}')
-					break
-				case 'blade':
-					modText = toggleComment(selText, '{{--', ' --}}', '{{~~', '~~}}')
-					break
-				case 'html':
-				default:
-					modText = toggleComment(selText, '<!--', ' -->', '<!~~', '~~>')
-					break
-			}
-			editor.edit(editBuilder => editBuilder.replace(editor.selection, modText))
-			return
+					let language = doc.languageId
+					let modText = ''
+					if (language === 'svelte' || language === 'vue')
+						language = wrappingRootTag(allText, selText)
+					switch (language) {
+						case 'javascript':
+						case 'typescript':
+						case 'css':
+							modText = toggleComment(selText, '/*', '*/', '/~', '~/')
+							break
+						case 'javascriptreact':
+						case 'typescriptreact':
+							modText = toggleComment(selText, '{/*', '*/}', '/~', '~/')
+							break
+						case 'tpl':
+						case 'twig':
+							modText = toggleComment(selText, '{#', '#}', '{~#', '#~}')
+							break
+						case 'blade':
+							modText = toggleComment(selText, '{{--', '--}}', '{{~~', '~~}}')
+							break
+						case 'html':
+						default:
+							modText = toggleComment(selText, '<!--', '-->', '<!~~', '~~>')
+							break
+					}
+
+					editBuilder.replace(selection, modText)
+				})
+			})
 		}
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ function wrappingRootTag(text, selection) {
 }
 
 function toggleComment(text, prefix, suffix, nestedPrefix, nestedSuffix) {
-	if (text.trimStart().startsWith(prefix)) {
+	if (text.trimStart().startsWith(prefix) && text.trimEnd().endsWith(suffix)) {
 		text = text.replaceAll(prefix, '')
 		text = text.replaceAll(suffix, '')
 		text = text.replaceAll(nestedPrefix, prefix)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 class NestComments {
-	updateNestedComments() {
+	public updateNestedComments() {
 		let editor = vscode.window.activeTextEditor
 		if (!editor) return
 		const doc = editor.document


### PR DESCRIPTION
Thanks for the extension, hope you find this useful to merge

- fix svelte/vue. These component libraries have single files which include html, js/ts, and css. This fix figures out which section you are in and applies the correct block comment tags.
- post trigger, the selection now include the initial block comment tag, allowing for back and forth toggling on/off. If accepted, the animated gifs will need redone too.
- selections which include leading linefeeds and whitespace before initial block comment tag work correctly now.
- support for js and ts files.
- code refactor/cleanup